### PR TITLE
React prop-types codemod

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-relay": "^0.3.2"
   },
   "dependencies": {
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "prop-types": "^15.5.10"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import { Component } from 'react';
 import Relay from 'react-relay';
 import pick from 'lodash/object/pick';
 import shallowEqual from './shallowEqual';


### PR DESCRIPTION
Use reacts prop-type package, since the PropTypes export is going away

https://github.com/facebook/prop-types#how-to-depend-on-this-package